### PR TITLE
add emitter cli arguments

### DIFF
--- a/bin/lsif-php
+++ b/bin/lsif-php
@@ -22,6 +22,8 @@ if (isset($options['h']) || isset($options['help'])) {
     echo "Options:\n";
     echo "  -h --help               display this help and exit\n";
     echo "     --memory-limit=\"1G\"  memory limit\n";
+    echo "     --id=1  the starting element ID to start from\n";
+    echo "     --filename=dump.lsif  the name of the file output\n";
     exit(0);
 }
 

--- a/bin/lsif-php
+++ b/bin/lsif-php
@@ -36,9 +36,9 @@ if (\ini_set('memory_limit', $memoryLimit) === false) {
     exit(1);
 }
 
-$id = intval($options['id'] ?? '0');
+$id = intval($options['id'] ?? '1') - 1;
 if ($id < 0) {
-    echo "Invalid id.\n";
+    echo "Invalid start element ID.\n";
     exit(1);
 }
 

--- a/bin/lsif-php
+++ b/bin/lsif-php
@@ -10,7 +10,7 @@ use LsifPhp\Indexer\Indexer;
 use LsifPhp\Protocol\Emitter;
 use LsifPhp\Protocol\ToolInfo;
 
-$options = \getopt('h', ['help', 'memory-limit:']);
+$options = \getopt('h', ['help', 'memory-limit:', 'id:', 'filename:']);
 if ($options === false) {
     echo "Cannot parse options.\n";
     exit(1);
@@ -36,11 +36,26 @@ if (\ini_set('memory_limit', $memoryLimit) === false) {
     exit(1);
 }
 
+$id = intval($options['id'] ?? '0');
+if ($id < 0) {
+    echo "Invalid id.\n";
+    exit(1);
+}
+
+$filename = $options['filename'] ?? 'dump.lsif';
+if (!\is_string($filename) || \substr($filename, -5) !== '.lsif') {
+    echo "Invalid filename. Must be a file ending with .lsif\n";
+    exit(1);
+}
+
 $projectRoot = \getcwd();
 $toolInfo = new ToolInfo('lsif-php', '0.0.6', \array_splice($argv, 1));
 
 $git = new Git();
-$emitter = new Emitter();
+$emitter = new Emitter(
+    filename: $filename,
+    id: $id,
+);
 $indexer = new Indexer($projectRoot, $emitter, $toolInfo, $git->version());
 $indexer->index();
 $emitter->write();

--- a/src/Protocol/Emitter.php
+++ b/src/Protocol/Emitter.php
@@ -18,9 +18,9 @@ final class Emitter
 
     private FileWriter $writer;
 
-    public function __construct(string $filename = 'dump.lsif')
+    public function __construct(string $filename = 'dump.lsif', int $id = 0)
     {
-        $this->id = 0;
+        $this->id = $id;
         $this->writer = new FileWriter($filename);
     }
 


### PR DESCRIPTION
I have a monorepo on GitLab, and it appears the code intelligence artifact only supports one artifact per pipeline. My plan is to combine the two files in a single job, then use the resulting file as the artifact.

In order to do so, I needed to be able to pass a starting ID for emitter. I figured adding the filename argument is a nice bonus. 

Similar issue: https://github.com/tcz717/LsifDotnet/issues/12